### PR TITLE
NDJSON 포맷으로 파일에 로그를 저장하는 로거 추가

### DIFF
--- a/hermes/misc/logger.py
+++ b/hermes/misc/logger.py
@@ -26,7 +26,29 @@ class JSONLogFormatter(logging.Formatter):
         return json.dumps(log)
 
 
+def _create_handler(log_path, formatter=None):
+    handler = logging.FileHandler(f"{log_path}/{SERVICE_NAME}.log")
+    handler.setFormatter(formatter)
+
+    return handler
+
+
 def _iso_time_format(dt):
     return '%04d-%02d-%02dT%02d:%02d:%02d.%03dZ' % (
         dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, int(dt.microsecond / 1000))
 
+
+def _set_sanic_logger(log_path):
+    handler = _create_handler(log_path, JSONLogFormatter())
+
+    sanic_logger.addHandler(handler)
+
+
+def _set_request_logger(log_path):
+    handler = _create_handler(log_path)
+
+    logger = logging.getLogger("sanic-request-log")
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+
+    return logger

--- a/hermes/misc/logger.py
+++ b/hermes/misc/logger.py
@@ -1,0 +1,5 @@
+
+def _iso_time_format(dt):
+    return '%04d-%02d-%02dT%02d:%02d:%02d.%03dZ' % (
+        dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, int(dt.microsecond / 1000))
+

--- a/hermes/misc/logger.py
+++ b/hermes/misc/logger.py
@@ -1,3 +1,30 @@
+import os
+import json
+import logging
+import traceback
+from datetime import datetime
+
+from sanic import Sanic, request, response
+from sanic.log import logger as sanic_logger
+
+from hermes.misc.constants import SERVICE_NAME
+
+
+class JSONLogFormatter(logging.Formatter):
+    def format(self, record):
+        log = {
+            "level": record.levelname,
+            "issued_at": _iso_time_format(datetime.utcnow()),
+            "logger": record.name,
+            "thread": record.threadName,
+            "module": record.module,
+            "filename": record.filename,
+            "line_no": record.lineno,
+            "msg": record.getMessage(),
+            "exec_info": ''.join(traceback.format_exception(*record.exc_info)) if record.exc_info else ''
+        }
+        return json.dumps(log)
+
 
 def _iso_time_format(dt):
     return '%04d-%02d-%02dT%02d:%02d:%02d.%03dZ' % (

--- a/hermes/presentation/app.py
+++ b/hermes/presentation/app.py
@@ -1,6 +1,7 @@
 from sanic import Sanic
 
 from hermes.misc.constants import LISTENER_OPTION, LOGO, SERVICE_NAME
+from hermes.misc.logger import set_logger
 from hermes.presentation.handler import add_error_handlers
 from hermes.presentation.listener import initialize, migrate, release
 from hermes.presentation.views.router import bp
@@ -9,6 +10,8 @@ from hermes.presentation.views.router import bp
 def create_app() -> Sanic:
     _app = Sanic(SERVICE_NAME)
     _app.config.LOGO = LOGO
+
+    set_logger(_app)
 
     _app.register_listener(initialize, LISTENER_OPTION[0])
     _app.register_listener(migrate, LISTENER_OPTION[0])


### PR DESCRIPTION
NDJSON은 여러개의 JSON 객체를 한 파일에 저장할 때 사용하는 포맷으로 `\n`으로 구분이 됩니다.

로그는 크게 두가지로, 시스템 로그와 액세스 로그가 있습니다

시스템 로그는 사닉 로그(직접 찍는 로그나 시작 메시지같은 것)나 파이썬이 발생시키는 traceback 로그이며
액세스 로그는 리퀘스트별로 생성되는 리퀘스트 정보와 리스폰스 정보를 담고 있는 로그입니다.

이 로그들은 hermes.log라는 파일에 NDJSON 포맷으로 저장이 되며 추후 셋팅될 Filebeat가 이 파일을 추적하며 엘라스틱서치에 데이터를 추가하게 될 것입니다.
