### PR TITLE
지원자 상태 레포지터리

### DIFF
--- a/hermes/adapters/repositories/applicant_status.py
+++ b/hermes/adapters/repositories/applicant_status.py
@@ -1,0 +1,51 @@
+from typing import Type, Dict, Any
+
+from marshmallow import Schema
+
+from hermes.adapters import AbstractAdapter
+from hermes.adapters.schema import ApplicantStatusSchema
+from hermes.entities.applicant_status import ApplicantStatus
+from hermes.misc.exceptions import ApplicantNotFoundException, ApplicantStatusNotFoundException
+from hermes.repositories.applicant_status import ApplicantStatusPersistentRepository, ApplicantStatusCacheRepository
+from hermes.repositories.connections import DBConnection, CacheConnection
+
+
+class ApplicantStatusRepositoryAdapter(AbstractAdapter):
+    schema = ApplicantStatusSchema()
+
+    def __init__(
+        self,
+        db_connection: Type[DBConnection],
+        cache_connection: Type[CacheConnection],
+    ):
+        self.persistence_repository = ApplicantStatusPersistentRepository(db_connection)
+        self.cache_repository = ApplicantStatusCacheRepository(cache_connection)
+
+    async def init(self, email: str):
+        await self.persistence_repository.init(email)
+
+    async def patch(self, email: str, patch_data: ApplicantStatus) -> None:
+        if not await self.persistence_repository.get_one(email):
+            raise ApplicantNotFoundException("Not Found")
+
+        patch_data = self._entity_to_data(self.schema, patch_data)
+
+        await self.persistence_repository.patch(email, patch_data)
+        await self.cache_repository.delete(email)
+
+    async def get_one(self, email: str) -> ApplicantStatus:
+        data = await self.cache_repository.get(email)
+
+        if not data:
+            data = await self.persistence_repository.get_one(email)
+            if not data:
+                raise ApplicantStatusNotFoundException("Not Found")
+
+        await self.cache_repository.set(data)
+        return self._data_to_entity(self.schema, data)
+
+    def _data_to_entity(self, schema: Schema, data: Dict[str, Any]) -> ApplicantStatus:
+        return schema.load(data)
+
+    def _entity_to_data(self, schema: Schema, entity) -> Dict[str, Any]:
+        return schema.dump(entity)

--- a/hermes/repositories/applicant_status.py
+++ b/hermes/repositories/applicant_status.py
@@ -1,0 +1,63 @@
+import asyncio
+import datetime
+from typing import Type, Dict, Any, Callable, Awaitable
+
+from hermes.repositories.connections import DBConnection, CacheConnection
+
+
+class ApplicantStatusPersistentRepository:
+    def __init__(self, connection: Type[DBConnection]):
+        self.connection = connection
+
+        self._patch_receipt_code = self._get_patch_function("receipt_code")
+        self._patch_is_paid = self._get_patch_function("is_paid")
+        self._patch_is_printed_application_arrived = self._get_patch_function(
+            "is_printed_application_arrived"
+        )
+        self._patch_is_passed_first_apply = self._get_patch_function("is_passed_first_apply")
+        self._patch_is_final_submit = self._get_patch_function("is_final_submit")
+        self._patch_exam_code = self._get_patch_function("exam_code")
+
+    async def init(self, email):
+        query = "INSERT INTO applicant_status (applicant_email) VALUES (%s)"
+        await self.connection.execute(query, email)
+
+    async def patch(self, email: str, patch_data: Dict[str, Any]) -> None:
+        tasks = list()
+        patch_data = {k: v for k, v in patch_data.items() if v}
+
+        for k, v in patch_data.items():
+            task: Callable[[Type[DBConnection], str, str], Awaitable[None]] = getattr(
+                self, f"_patch_{k}", None
+            )
+
+            if task:
+                tasks.append(task(self.connection, email, v))
+
+        await asyncio.gather(*tasks)
+
+    async def get_one(self, email: str) -> Dict[str, Any]:
+        query = """
+            SELECT 
+            applicant_email,
+            receipt_code,
+            is_paid,
+            is_printed_application_arrived,
+            is_passed_first_apply,
+            is_final_submit,
+            exam_code
+            FROM applicant_status
+            WHERE applicant_email = %s;
+        """
+        return await self.connection.fetchone(query, email)
+
+    def _get_patch_function(self, column: str) -> Callable[[str, str], Awaitable[None]]:
+        async def _patch_function(email: str, value: Any) -> None:
+            query = (
+                f"UPDATE applicant_status SET {column} = %s, updated_at = %s WHERE applicant_email = %s"
+            )
+
+            await self.connection.execute(query, value, datetime.datetime.now(), email)
+
+        return _patch_function
+

--- a/hermes/repositories/applicant_status.py
+++ b/hermes/repositories/applicant_status.py
@@ -61,3 +61,20 @@ class ApplicantStatusPersistentRepository:
 
         return _patch_function
 
+
+class ApplicantStatusCacheRepository:
+    _key_template: str = "hermes:applicant:status:{0}"
+
+    def __init__(self, connection: Type[CacheConnection]):
+        self.connection = connection
+
+    async def set(self, applicant: Dict[str, Any]) -> None:
+        await self.connection.set(
+            self._key_template.format(applicant["applicant_email"]), applicant
+        )
+
+    async def get(self, email: str) -> Dict[str, Any]:
+        return await self.connection.get(self._key_template.format(email))
+
+    async def delete(self, email: str) -> None:
+        return await self.connection.delete(self._key_template.format(email))


### PR DESCRIPTION
지원자 상태에 관한 레포지터리들과 그 어댑터입니다
persistent repo는 MySQL 커넥션을 사용하는 일반 레포지터리고 cache repo는 Redis 커넥션을 사용하는 캐싱용 레포지터리 입니다.

어댑터는 두가지 레포지터리를 묶어서 유즈케이스 계층과의 통신을 위해 사용됩니다