### PR TITLE
Authoriazation 관련 기능을 추가

### DIFF
--- a/hermes/misc/exceptions.py
+++ b/hermes/misc/exceptions.py
@@ -11,6 +11,11 @@ class BadRequest(SanicException):
     pass
 
 
+@add_status_code(403)
+class Forbidden(SanicException):
+    pass
+
+
 class AdminAlreadyExistException(Exception):
     pass
 

--- a/hermes/presentation/views/applicant.py
+++ b/hermes/presentation/views/applicant.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Union
 from sanic.request import Request
 from sanic.response import json
 from sanic.views import HTTPMethodView
+from werkzeug.security import check_password_hash
 
 from hermes.adapters.repositories.applicant import ApplicantRepositoryAdapter
 from hermes.adapters.repositories.applicant_status import (
@@ -89,7 +90,7 @@ class ApplicantAuthorizationView(HTTPMethodView):
             raise BadRequest("Bad Request")
 
         applicant = await self.service.get_one(email)
-        if applicant["password"] != password:
+        if not check_password_hash(applicant["password"], password):
             raise Forbidden("Authorization failed")
 
         return json({"msg": "Authorization succeed"}, 200)

--- a/hermes/presentation/views/router.py
+++ b/hermes/presentation/views/router.py
@@ -5,6 +5,7 @@ from hermes.presentation.views.applicant import (
     ApplicantBatchView,
     ApplicantDetailView,
     ApplicantView,
+    ApplicantAuthorizationView,
 )
 from hermes.presentation.views.applicant_status import ApplicantStatusView
 
@@ -13,6 +14,7 @@ bp = Blueprint("user", url_prefix="/api/v1")  # pylint: disable=invalid-name
 bp.add_route(ApplicantView.as_view(), "/applicant")
 bp.add_route(ApplicantBatchView.as_view(), "/applicant/batch")
 bp.add_route(ApplicantDetailView.as_view(), "/applicant/<email>")
+bp.add_route(ApplicantAuthorizationView.as_view(), '/applicant/<email>/authorization')
 bp.add_route(ApplicantStatusView.as_view(), "/applicant/<email>/status")
 bp.add_route(AdminView.as_view(), "/admin")
 bp.add_route(AdminDetailView.as_view(), "/admin/<admin_id>")

--- a/hermes/presentation/views/router.py
+++ b/hermes/presentation/views/router.py
@@ -1,6 +1,11 @@
 from sanic import Blueprint
 
-from hermes.presentation.views.admin import AdminBatchView, AdminDetailView, AdminView
+from hermes.presentation.views.admin import (
+    AdminView,
+    AdminBatchView,
+    AdminDetailView,
+    AdminAuthorizationView,
+)
 from hermes.presentation.views.applicant import (
     ApplicantBatchView,
     ApplicantDetailView,
@@ -17,5 +22,6 @@ bp.add_route(ApplicantDetailView.as_view(), "/applicant/<email>")
 bp.add_route(ApplicantAuthorizationView.as_view(), '/applicant/<email>/authorization')
 bp.add_route(ApplicantStatusView.as_view(), "/applicant/<email>/status")
 bp.add_route(AdminView.as_view(), "/admin")
-bp.add_route(AdminDetailView.as_view(), "/admin/<admin_id>")
 bp.add_route(AdminBatchView.as_view(), "/admin/batch")
+bp.add_route(AdminDetailView.as_view(), "/admin/<admin_id>")
+bp.add_route(AdminAuthorizationView.as_view(), "/admin/<admin_id>/authorization")

--- a/tests/endpoint_test_data.py
+++ b/tests/endpoint_test_data.py
@@ -177,6 +177,41 @@ def admin_detail_view_test_data():
     return test_set
 
 
+def admin_authorization_view_test_data():
+    test_set = [
+        generate_endpoint_test_data(
+            method="POST",
+            endpoint=f"/api/v1/admin/{generate_admin_id(0)}/authorization",
+            query_param={},
+            request_body={
+                "password": f"pw:{generate_admin_id(0)}",
+            },
+            expected_response_status=200,
+            expected_response_body=status_message_response(),
+        ),
+        generate_endpoint_test_data(
+            method="POST",
+            endpoint=f"/api/v1/admin/{generate_admin_id(0)}/authorization",
+            query_param={},
+            request_body={
+                "password": f"WrongPassWord",
+            },
+            expected_response_status=403,
+            expected_response_body=status_message_response(),
+        ),
+        generate_endpoint_test_data(
+            method="POST",
+            endpoint=f"/api/v1/admin/{generate_admin_id(0)}/authorization",
+            query_param={},
+            request_body={},
+            expected_response_status=400,
+            expected_response_body=status_message_response(),
+        ),
+    ]
+
+    return test_set
+
+
 def applicant_view_test_data():
     test_set = [
         generate_endpoint_test_data(

--- a/tests/endpoint_test_data.py
+++ b/tests/endpoint_test_data.py
@@ -10,7 +10,7 @@ from tests.helpers.applicant import (
     applicant_batch_response,
     applicant_response,
     generate_applicant_email,
-)
+    generate_applicant_id)
 from tests.helpers.applicant_status import applicant_status_dunno_response
 from tests.helpers.util import (
     generate_endpoint_test_data,
@@ -327,6 +327,41 @@ def applicant_detail_view_test_data():
             request_body={
                 "birth_date": "WrongDateTypeLMAO",
             },
+            expected_response_status=400,
+            expected_response_body=status_message_response(),
+        ),
+    ]
+
+    return test_set
+
+
+def applicant_authorization_view_test_data():
+    test_set = [
+        generate_endpoint_test_data(
+            method="POST",
+            endpoint=f"/api/v1/applicant/{generate_applicant_email(0)}/authorization",
+            query_param={},
+            request_body={
+                "password": f"pw:{generate_applicant_id(0)}",
+            },
+            expected_response_status=200,
+            expected_response_body=status_message_response(),
+        ),
+        generate_endpoint_test_data(
+            method="POST",
+            endpoint=f"/api/v1/applicant/{generate_applicant_email(0)}/authorization",
+            query_param={},
+            request_body={
+                "password": f"WrongPassWord",
+            },
+            expected_response_status=403,
+            expected_response_body=status_message_response(),
+        ),
+        generate_endpoint_test_data(
+            method="POST",
+            endpoint=f"/api/v1/applicant/{generate_applicant_email(0)}/authorization",
+            query_param={},
+            request_body={},
             expected_response_status=400,
             expected_response_body=status_message_response(),
         ),

--- a/tests/helpers/admin.py
+++ b/tests/helpers/admin.py
@@ -38,7 +38,7 @@ async def create_admin_table(
 def create_admin_dummy_object(admin_index: int, privileges: str = "ADMINISTRATION"):
     return Admin(
         admin_email=generate_admin_email(admin_index),
-        admin_password=generate_random_string(),
+        admin_password=f"pw:{generate_admin_id(admin_index)}",
         admin_type=privileges,
         admin_id=generate_admin_id(admin_index),
         admin_name=generate_random_string(),

--- a/tests/helpers/applicant.py
+++ b/tests/helpers/applicant.py
@@ -3,6 +3,8 @@ import random
 import uuid
 from typing import Type
 
+from werkzeug.security import generate_password_hash
+
 from tests.helpers.util import (
     DunnoValue,
     generate_random_phone_number,
@@ -64,7 +66,7 @@ async def save_applicants(applicant_dummy_set):
         await MySQLConnection.execute(
             query,
             applicant.email,
-            applicant.password,
+            generate_password_hash(applicant.password),
             applicant.applicant_name,
             applicant.sex,
             applicant.birth_date,

--- a/tests/helpers/applicant.py
+++ b/tests/helpers/applicant.py
@@ -28,7 +28,7 @@ async def create_applicant_table(db_connection: Type[DBConnection]):
 def create_applicant_dummy_object(applicant_index: int):
     return Applicant(
         email=generate_applicant_email(applicant_index),
-        password=generate_random_string(),
+        password=f"pw:{generate_applicant_id(applicant_index)}",
         applicant_name=generate_random_string(),
         sex="FEMALE" if applicant_index % 2 else "MALE",
         birth_date=datetime.datetime.now().date(),

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -16,6 +16,7 @@ from tests.endpoint_test_data import (
     applicant_status_view_test_data,
     applicant_view_test_data,
     applicant_authorization_view_test_data,
+    admin_authorization_view_test_data
 )
 
 
@@ -24,6 +25,7 @@ from tests.endpoint_test_data import (
     admin_view_test_data()
     + admin_batch_view_test_data()
     + admin_detail_view_test_data()
+    + admin_authorization_view_test_data()
     + applicant_view_test_data()
     + applicant_batch_view_test_data()
     + applicant_detail_view_test_data()

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -15,6 +15,7 @@ from tests.endpoint_test_data import (
     applicant_detail_view_test_data,
     applicant_status_view_test_data,
     applicant_view_test_data,
+    applicant_authorization_view_test_data,
 )
 
 
@@ -26,6 +27,7 @@ from tests.endpoint_test_data import (
     + applicant_view_test_data()
     + applicant_batch_view_test_data()
     + applicant_detail_view_test_data()
+    + applicant_authorization_view_test_data()
     + applicant_status_view_test_data(),
 )
 async def test_endpoint(


### PR DESCRIPTION
Chanel이 JWT를 생성하기 위해 유저 이메일(아이디)과 패스워드가 일치하는지 확인해야 합니다.
따라서 패스 파라미터로 이메일(아이디)을 받고 바디로 패스워드를 넘겨받아 정보가 올바른지 확인하는 API를 추가했습니다

추가로 테스트를 검토하면서 기존 지원자 테스트 더미 데이터 셋을 DB에 저장할 때 패스워드를 해싱하지 않아 해싱하도록 변경하였더니 지원자 인가 API가 해싱한 값을 체크하는 대신 평문 데이터값을 비교한다는 사실이 드러나 지원자 인가 API를 수정하였습니다